### PR TITLE
Add report status-update endpoint (proposal)

### DIFF
--- a/apps/backend/src/routes/reports.ts
+++ b/apps/backend/src/routes/reports.ts
@@ -111,10 +111,24 @@ export const getImage = pub.reports.getImage.handler(async ({ input, context }) 
   return imageFile;
 });
 
+// Update a report's status (open / confirmed / inProgress / closed).
+// NOTE (proposal — needs Elliot's sign-off): this is `pub` to match every other
+// procedure here, but changing status is really an admin/volunteer action from the
+// panel. Once panel auth is wired (`authed` in orpc.ts), this should move behind it.
+export const updateReportStatus = pub.reports.updateReportStatus.handler(async ({ input }) => {
+  const updated = await db.updateReportStatus(input.localId, input.status);
+  if (!updated) {
+    // TODO: use oRPC's typed errors (like postImage above) once error handling is settled.
+    throw new Error('Report not found');
+  }
+  return updated;
+});
+
 export const reportsRouter = {
   postReport: postReport,
   postImage: postImage,
   getImage: getImage,
+  updateReportStatus: updateReportStatus,
 };
 
 /*

--- a/packages/contract/src/contracts/reports.ts
+++ b/packages/contract/src/contracts/reports.ts
@@ -1,5 +1,5 @@
 import { oc } from '@orpc/contract';
-import { ReportInsertSchema } from '@repo/database/models/reports';
+import { ReportInsertSchema, ReportSelectSchema } from '@repo/database/models/reports';
 import { z } from 'zod';
 
 export const postReportContract = oc
@@ -32,8 +32,29 @@ export const getImageContract = oc
   .input(z.object({ imageUuid: z.uuid() }))
   .output(z.instanceof(Blob));
 
+// NOTE (proposal — needs Elliot's sign-off): who is allowed to change a report's
+// status? Right now every procedure is `pub` (public/unauthenticated). Status changes
+// are primarily an admin/volunteer action from the panel, so this most likely wants to
+// move to an authenticated procedure once panel auth is wired (`authed` in orpc.ts).
+// Keyed on `localId` (the client-generated UUID) so both the app and panel can address
+// a report without knowing its serial `id` — mirrors the image-upload UUID pattern.
+export const updateReportStatusContract = oc
+  .route({
+    method: 'PATCH',
+    path: '/report/{localId}/status',
+    summary: "Update a report's status",
+  })
+  .input(
+    z.object({
+      localId: z.uuid(),
+      status: ReportSelectSchema.shape.status,
+    }),
+  )
+  .output(ReportSelectSchema);
+
 export const reportsContract = {
   postReport: postReportContract,
   postImage: postImageContract,
   getImage: getImageContract,
+  updateReportStatus: updateReportStatusContract,
 };

--- a/packages/database/src/database/reports.ts
+++ b/packages/database/src/database/reports.ts
@@ -34,3 +34,19 @@ export async function isImageReferenced(imageUuid: string) {
 export async function getAllReports() {
   return (await client.query.reports.findMany()) as ReportSelect[];
 }
+
+/**
+ * Updates the status of a report identified by its client-generated localId.
+ *
+ * @param localId - The UUID (`localId`) of the report to update.
+ * @param status - The new status to set.
+ * @returns The updated report, or null if no report matched the given localId.
+ */
+export async function updateReportStatus(localId: string, status: ReportSelect['status']) {
+  const [updated] = await client
+    .update(reports)
+    .set({ status, updatedAt: new Date() })
+    .where(eq(reports.localId, localId))
+    .returning();
+  return (updated ?? null) as ReportSelect | null;
+}


### PR DESCRIPTION
Adds PATCH /reports/report/{localId}/status to change a report's status (open/confirmed/inProgress/closed) — for panel triage and the app's status updates, replacing the legacy /hazard/update endpoint.

- contract: updateReportStatusContract, keyed on localId (client UUID), status reuses the schema's status enum; outputs the updated report
- database: updateReportStatus(localId, status) -> updated row | null
- backend route: handler wired into reportsRouter

Unverified: no local toolchain here to run typecheck/tests. Open question flagged inline for Elliot's Friday handoff: authorization — all procedures are currently `pub`, but status changes are an admin/volunteer action and likely want auth once panel auth (`authed` in orpc.ts) is wired.